### PR TITLE
Rename Post to PostUtils

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,7 +2,7 @@
 
 use Lean\AbstractCollectionEndpoint;
 use Lean\Endpoints\Collection\Filter;
-use Lean\Endpoints\Collection\Post;
+use Lean\Endpoints\Collection\PostUtils;
 
 /**
  * Class that returns a collection of posts using dynamic arguments.
@@ -97,8 +97,8 @@ class Collection extends AbstractCollectionEndpoint {
 				'posts_link' => str_replace( home_url(), '', get_author_posts_url( $the_author->ID ) ),
 			],
 			'date' => strtotime( $the_post->post_date_gmt ),
-			'thumbnail' => Post::get_thumbnail( $the_post, $this->args ),
-			'terms' => Post::get_terms( $the_post ),
+			'thumbnail' => PostUtils::get_thumbnail( $the_post, $this->args ),
+			'terms' => PostUtils::get_terms( $the_post ),
 		];
 
 		return apply_filters( Filter::ITEM_FORMAT, $item, $the_post, $this->args );

--- a/src/Collection/PostUtils.php
+++ b/src/Collection/PostUtils.php
@@ -6,7 +6,7 @@
  * @package Endpoints\Collection;
  * @since 0.1.0
  */
-class Post {
+class PostUtils {
 	/**
 	 * Get the thumbnail
 	 *


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)

Error message:
Fatal error: Cannot use Lean\Endpoints\Collection\Post as Post because the name is already in use in /var/www/wp.shootx9.moxie-staging.com/htdocs/wp-content/plugins/shootx9/vendor/moxie-lean/wp-endpoints-collection/src/Collection.php on line 5
- **What is the new behavior (if this is a feature change)?**

Show json
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No
- **Other information**:

Ticket #17
